### PR TITLE
docs(readme): use python3 -m pip, the "good" way

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 * Python 3 (because there's few languages with good API interfaces, and C++ isn't one of them)
-* Various dependencies: `pip3 install -r requirements.txt`
+* Various dependencies: `python3 -m pip install -r requirements.txt`
 * 2k+ reputation on Stack Overflow (this tool actively blocks non-moderators with &lt;2k reputation to avoid review queue flooding)
 * A terminal that supports colorama (potentially optional, but definitely a requirement for QOL)
 


### PR DESCRIPTION
Let's face it: we all forget about it, but it's the best way to do it

too lazy to make it on another branch :kek: 